### PR TITLE
shader_bytecode: Add instruction decoding for MADI format.

### DIFF
--- a/include/nihstro/shader_bytecode.h
+++ b/include/nihstro/shader_bytecode.h
@@ -609,6 +609,16 @@ union Instruction {
 
         BitField<0x18, 0x5, DestRegister> dest;
     } mad;
+
+    union {
+        BitField<0x00, 0x5, uint32_t> operand_desc_id;
+
+        BitField<0x05, 0x7, SourceRegister> src3;
+        BitField<0x0c, 0x5, SourceRegister> src2;
+        BitField<0x11, 0x7, SourceRegister> src1;
+
+        BitField<0x18, 0x5, DestRegister> dest;
+    } madi;
 };
 static_assert(sizeof(Instruction) == 0x4, "Incorrect structure size");
 static_assert(std::is_standard_layout<Instruction>::value, "Structure does not have standard layout");


### PR DESCRIPTION
Added the vertex shader instruction decoding format for MADI. Cf http://3dbrew.org/wiki/Shader_Instruction_Set#Instruction_formats format 5i.